### PR TITLE
feat: poi 검색 기능 개선

### DIFF
--- a/app/controllers/poiController.js
+++ b/app/controllers/poiController.js
@@ -1,12 +1,18 @@
 const fs = require('fs');
 const xlsx = require('xlsx');
 
-// List all POIs
+// List POIs with optional query filters
 exports.list = (req, res) => {
+  const p = {};
+  if (typeof req.query.q === 'string' && req.query.q.trim()) p.q = req.query.q.trim();
+  const limRaw = Number(req.query.limit);
+  const lim = Number.isFinite(limRaw) ? limRaw : null;
+  if (lim !== null) p.limit = Math.max(1, Math.min(100, Math.floor(lim)));
+
   global.psql.select(
     'poi',
     'selectAll',
-    {},
+    p,
     (rows) => {
       res.json(global.funcCmmn.getReturnMessage({ resultData: rows, resultCnt: rows.length }));
     },

--- a/app/mapper/index-mapper.xml
+++ b/app/mapper/index-mapper.xml
@@ -2,8 +2,18 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="poi">
-    <select id="selectAll" resultType="map">
-        SELECT * FROM poi
+    <select id="selectAll" parameterType="map" resultType="map">
+        SELECT *
+        FROM poi
+        <where>
+            <if test="q != null and q != ''">
+                AND lower(name) like '%' || lower(#{q}) || '%'
+            </if>
+        </where>
+        ORDER BY name
+        <if test="limit != null">
+            LIMIT #{limit}
+        </if>
     </select>
 
     <insert id="insertPoiBulk" parameterType="map">

--- a/public/javascripts/app.js
+++ b/public/javascripts/app.js
@@ -157,9 +157,9 @@
     if (state.suggest.box) state.suggest.box.innerHTML = '';
   }
 
-  function updateSuggestions(query) {
-    if (!state.suggest.box) return;
-    const q = normalize(query);
+  function updateSuggestions(input) {
+    if (!state.suggest.box || !input) return;
+    const q = normalize(input.value);
     if (!q) { hideSuggestions(); return; }
     const scored = state.pois
       .map(p => ({ p, s: scoreName(p?.name || '', q) }))
@@ -168,15 +168,16 @@
       .slice(0, 10);
     state.suggest.items = scored.map(x => x.p);
     state.suggest.active = scored.length ? 0 : -1;
-    renderSuggestions(q);
+    renderSuggestions(input);
   }
 
-  function renderSuggestions(q) {
+  function renderSuggestions(input) {
     const box = state.suggest.box;
     if (!box) return;
     box.innerHTML = '';
     if (!state.suggest.items.length) { hideSuggestions(); return; }
     box.style.display = 'block';
+    const q = normalize(input?.value || '');
     state.suggest.items.forEach((p, idx) => {
       const item = document.createElement('div');
       item.style.padding = '8px 10px';
@@ -204,14 +205,12 @@
       item.addEventListener('mousedown', (ev) => {
         ev.preventDefault();
         ev.stopPropagation();
-        const input = document.querySelector('input[type="search"]');
         selectSuggestion(idx, input);
       });
       // Fallback for environments where click is preferred
       item.addEventListener('click', (ev) => {
         ev.preventDefault();
         ev.stopPropagation();
-        const input = document.querySelector('input[type="search"]');
         selectSuggestion(idx, input);
       });
       box.appendChild(item);
@@ -238,7 +237,7 @@
 
     // Suggestions: init and wire interactions
     ensureSuggestBox(input);
-    const onInput = debounce(() => updateSuggestions(input.value), 200);
+    const onInput = debounce(() => updateSuggestions(input), 200);
     input?.addEventListener('input', onInput);
     input?.addEventListener('keydown', (e) => {
       if (e.key === 'Enter') {

--- a/public/javascripts/app.js
+++ b/public/javascripts/app.js
@@ -6,6 +6,7 @@
     poiMarkers: [],
     pois: [],
     uiBound: false,
+    suggest: { box: null, items: [], active: -1 },
   };
 
   function initMap() {
@@ -71,10 +72,33 @@
     }
   }
 
-  function findPoiByName(query) {
-    if (!query) return null;
-    const q = query.trim().toLowerCase();
-    return state.pois.find((p) => (p.name || '').toLowerCase().includes(q));
+  // ---------- Search scoring helpers ----------
+  function normalize(s) { return String(s || '').trim().toLowerCase(); }
+
+  function scoreName(name, term) {
+    const n = normalize(name);
+    const q = normalize(term);
+    if (!q) return 0;
+    if (n === q) return 100;              // exact match
+    if (n.startsWith(q)) return 80;       // starts-with
+    const tokens = n.split(/\s+/);
+    if (tokens.includes(q)) return 70;    // token match
+    const idx = n.indexOf(q);
+    if (idx >= 0) return 60 - idx / 100;  // partial (earlier index slightly better)
+    return 0;
+  }
+
+  function findBestPoi(query) {
+    let best = null;
+    let bestScore = 0;
+    for (const p of state.pois) {
+      const s = scoreName(p?.name || '', query);
+      if (s > bestScore) { best = p; bestScore = s; continue; }
+      if (s === bestScore && s > 0 && best) {
+        if (String(p.name || '').localeCompare(String(best.name || ''), 'ko') < 0) best = p;
+      }
+    }
+    return best;
   }
 
   function centerOnPoi(poi) {
@@ -85,8 +109,124 @@
 
   function performSearch(inputEl) {
     if (!inputEl) return;
-    const poi = findPoiByName(inputEl.value);
+    const poi = findBestPoi(inputEl.value);
     if (poi) centerOnPoi(poi);
+  }
+
+  // ---------- Suggestion dropdown ----------
+  function debounce(fn, wait) {
+    let t = null;
+    return function(...args) {
+      if (t) clearTimeout(t);
+      t = setTimeout(() => fn.apply(this, args), wait);
+    };
+  }
+
+  function ensureSuggestBox(input) {
+    if (!input) return;
+    const label = input.parentElement;
+    if (!label) return;
+    if (getComputedStyle(label).position === 'static') label.style.position = 'relative';
+    const box = document.createElement('div');
+    box.style.position = 'absolute';
+    box.style.top = '100%';
+    box.style.left = '0';
+    box.style.right = '0';
+    box.style.zIndex = '50';
+    box.style.background = '#fff';
+    box.style.border = '1px solid #e5e7eb';
+    box.style.borderTop = 'none';
+    box.style.maxHeight = '260px';
+    box.style.overflowY = 'auto';
+    box.style.display = 'none';
+    box.setAttribute('role', 'listbox');
+    label.appendChild(box);
+    state.suggest.box = box;
+
+    document.addEventListener('click', (e) => {
+      if (!box || !input) return;
+      if (e.target === input || box.contains(e.target)) return;
+      hideSuggestions();
+    });
+  }
+
+  function hideSuggestions() {
+    state.suggest.items = [];
+    state.suggest.active = -1;
+    if (state.suggest.box) state.suggest.box.style.display = 'none';
+    if (state.suggest.box) state.suggest.box.innerHTML = '';
+  }
+
+  function updateSuggestions(query) {
+    if (!state.suggest.box) return;
+    const q = normalize(query);
+    if (!q) { hideSuggestions(); return; }
+    const scored = state.pois
+      .map(p => ({ p, s: scoreName(p?.name || '', q) }))
+      .filter(x => x.s > 0)
+      .sort((a, b) => b.s - a.s || String(a.p.name||'').localeCompare(String(b.p.name||''), 'ko'))
+      .slice(0, 10);
+    state.suggest.items = scored.map(x => x.p);
+    state.suggest.active = scored.length ? 0 : -1;
+    renderSuggestions(q);
+  }
+
+  function renderSuggestions(q) {
+    const box = state.suggest.box;
+    if (!box) return;
+    box.innerHTML = '';
+    if (!state.suggest.items.length) { hideSuggestions(); return; }
+    box.style.display = 'block';
+    state.suggest.items.forEach((p, idx) => {
+      const item = document.createElement('div');
+      item.style.padding = '8px 10px';
+      item.style.cursor = 'pointer';
+      item.setAttribute('role', 'option');
+      item.setAttribute('aria-selected', String(idx === state.suggest.active));
+      item.style.background = (idx === state.suggest.active) ? '#f3f4f6' : '#fff';
+
+      const name = String(p.name || '');
+      const n = name.toLowerCase();
+      const i = n.indexOf(q.toLowerCase());
+      if (i >= 0) {
+        const before = document.createTextNode(name.slice(0, i));
+        const mark = document.createElement('mark');
+        mark.textContent = name.slice(i, i + q.length);
+        mark.style.background = '#fde68a';
+        mark.style.padding = '0 0.1em';
+        const after = document.createTextNode(name.slice(i + q.length));
+        item.appendChild(before); item.appendChild(mark); item.appendChild(after);
+      } else {
+        item.textContent = name;
+      }
+
+      // Use mousedown to select before any blur/hide logic, and prevent label default
+      item.addEventListener('mousedown', (ev) => {
+        ev.preventDefault();
+        ev.stopPropagation();
+        const input = document.querySelector('input[type="search"]');
+        selectSuggestion(idx, input);
+      });
+      // Fallback for environments where click is preferred
+      item.addEventListener('click', (ev) => {
+        ev.preventDefault();
+        ev.stopPropagation();
+        const input = document.querySelector('input[type="search"]');
+        selectSuggestion(idx, input);
+      });
+      box.appendChild(item);
+    });
+  }
+
+  function selectSuggestion(idx, input) {
+    const poi = state.suggest.items[idx];
+    if (!poi) return;
+    if (input) {
+      input.value = poi.name || '';
+      try { input.focus(); } catch (_) {}
+    }
+    performSearch(input);
+    hideSuggestions();
   }
 
   function bindUI() {
@@ -96,8 +236,19 @@
     const buttons = document.querySelectorAll('[data-location="box"] button');
     const [btnRefresh, btnImport] = buttons;
 
+    // Suggestions: init and wire interactions
+    ensureSuggestBox(input);
+    const onInput = debounce(() => updateSuggestions(input.value), 200);
+    input?.addEventListener('input', onInput);
     input?.addEventListener('keydown', (e) => {
-      if (e.key === 'Enter') performSearch(input);
+      if (e.key === 'Enter') {
+        if (state.suggest.active >= 0) {
+          selectSuggestion(state.suggest.active, input);
+        } else {
+          performSearch(input);
+        }
+        e.preventDefault();
+      }
     });
     btnSearch?.addEventListener('click', () => performSearch(input));
 


### PR DESCRIPTION
관련 이슈: #24 

 배경

  - 기존 검색은 부분 일치의 첫 결과만 선택되어 “쉼터” 검색 시 “물멍 쉼터”로 이동하는 문제가 있었음.
  - 입력 중에 연관 결과 미리보기가 없어 탐색 효율이 낮았음.

  핵심 변경

  - 검색 로직 개선
      - 점수 기반 선택: 정확 일치 > 시작 일치 > 단어 경계 일치 > 부분 일치(앞쪽 가점)
      - 동점 시 한국어 locale 기준으로 안정 정렬
  - 제안 드롭다운 추가
      - 입력 200ms 디바운스 → 상위 10개 제안 표시
      - 항목 클릭 시 입력창에 반영 후 검색 실행
  - 서버 필터 도입
      - GET /poi에 q(이름 부분 일치), limit(1–100) 추가
      - 응답 정렬: ORDER BY name

  변경 파일 요약

  - Frontend
      - public/javascripts/app.js: 점수 기반 검색, 제안 드롭다운, 클릭 인터랙션, 디바운스 추가
  - Backend
      - app/controllers/poiController.js: q, limit 파싱 및 매퍼 전달
      - app/mapper/index-mapper.xml: WHERE(q), ORDER BY name, LIMIT 반영

  검증 방법

  - 로컬
      - npm ci && npm test
      - npm start → http://localhost:3535/index
  - Docker
      - cp .env.example .env 후 docker compose up -d --build web
      - 브라우저에서 검색 UX 확인
