### PR TITLE
refactor: 검색 파라미터 및 관련 테스트 제거

### DIFF
--- a/app/controllers/poiController.js
+++ b/app/controllers/poiController.js
@@ -1,18 +1,12 @@
 const fs = require('fs');
 const xlsx = require('xlsx');
 
-// List POIs with optional query filters
+// List all POIs
 exports.list = (req, res) => {
-  const p = {};
-  if (typeof req.query.q === 'string' && req.query.q.trim()) p.q = req.query.q.trim();
-  const limRaw = Number(req.query.limit);
-  const lim = Number.isFinite(limRaw) ? limRaw : null;
-  if (lim !== null) p.limit = Math.max(1, Math.min(100, Math.floor(lim)));
-
   global.psql.select(
     'poi',
     'selectAll',
-    p,
+    {},
     (rows) => {
       res.json(global.funcCmmn.getReturnMessage({ resultData: rows, resultCnt: rows.length }));
     },
@@ -22,7 +16,7 @@ exports.list = (req, res) => {
   );
 };
 
-// Import POIs from uploaded Excel file
+// Import POIs from an uploaded Excel file
 exports.importExcel = async (req, res) => {
   let filepath;
   try {
@@ -30,7 +24,7 @@ exports.importExcel = async (req, res) => {
       return res.status(400).json(global.funcCmmn.getReturnMessage({ isErr: true, code: 400, message: 'No file uploaded' }));
     }
 
-    // Use single transaction for all DB changes
+    // Use a single transaction for all DB changes
     const client = await global.psql.getConnection();
     const begin = async () => client.query('BEGIN');
     const commit = async () => client.query('COMMIT');

--- a/app/mapper/index-mapper.xml
+++ b/app/mapper/index-mapper.xml
@@ -2,18 +2,8 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="poi">
-    <select id="selectAll" parameterType="map" resultType="map">
-        SELECT *
-        FROM poi
-        <where>
-            <if test="q != null and q != ''">
-                AND lower(name) like '%' || lower(#{q}) || '%'
-            </if>
-        </where>
-        ORDER BY name
-        <if test="limit != null">
-            LIMIT #{limit}
-        </if>
+    <select id="selectAll" resultType="map">
+        SELECT * FROM poi
     </select>
 
     <insert id="insertPoiBulk" parameterType="map">

--- a/tests/poiList.test.js
+++ b/tests/poiList.test.js
@@ -9,22 +9,12 @@ jest.mock('../app/modules/db.psql.js', () => {
     rows: [
       { id: 1, name: 'Cafe A', latitude: 37.1, longitude: 127.1 },
       { id: 2, name: 'Park B', latitude: 37.2, longitude: 127.2 },
-      { id: 3, name: 'Cafe Alpha', latitude: 37.3, longitude: 127.3 },
     ],
-    lastParam: null,
   };
   return {
     __control: control,
-    select: (_mapper, _id, param, ok, err) => {
-      control.lastParam = param;
+    select: (_mapper, _id, _param, ok, err) => {
       if (control.shouldError) return err && err(new Error('mock select failure'));
-      let out = control.rows.slice();
-      if (param && param.q) {
-        const q = String(param.q).toLowerCase();
-        out = out.filter(r => String(r.name || '').toLowerCase().includes(q));
-      }
-      // no coordinate-based filtering in current scope
-      if (param && param.limit != null) out = out.slice(0, param.limit);
       return ok && ok(out);
     },
   };
@@ -49,12 +39,6 @@ describe('GET /poi', () => {
     expect(res.body.resultCnt).toBe(2);
     // basic field check
     expect(res.body.resultData[0]).toMatchObject({ name: 'Cafe A', latitude: 37.1, longitude: 127.1 });
-  });
-
-  test('200 → filters by q and limit', async () => {
-    const res = await request(app).get('/poi?q=cafe&limit=1').expect(200);
-    expect(res.body.resultCnt).toBe(1);
-    expect(res.body.resultData[0].name.toLowerCase()).toContain('cafe');
   });
 
   test('500 → handles DB error path', async () => {


### PR DESCRIPTION
관련 이슈: #26

배경
- 서버 기반 검색 정렬 작업을 롤백
- 현재 사용되지 않는 기능

변경사항 요약
- server: poiController.list에서 q/limit 파라미터 사용 제거, selectAll에 빈 파라미터 전달.
- mapper: selectAll을 SELECT * FROM poi로 단순화(동적 WHERE/ORDER BY/LIMIT 제거).
- tests: tests/poiList.test.js에서 q/limit 필터·정렬 검증 제거 및 mock 단순화.